### PR TITLE
download-and-cut.sh script improvements

### DIFF
--- a/scripts/download-and-cut.sh
+++ b/scripts/download-and-cut.sh
@@ -106,6 +106,10 @@ else
   if [ "$#" -eq 4 ]; then
     cutMP3 "$fileName" "$3" "$4"
   fi
+  if [ -x "$(command -v ffmpeg-normalize)" ]; then
+    ffmpeg-normalize "$tmpDir/$fileName" -o "$tmpDir/$fileName" \
+    -nt ebu --dual-mono -c:a libmp3lame -fv >> $logFile 2>&1
+  fi
   echo mv "$tmpDir/$fileName" "$defaultLibraryDir/$fileName" >> $logFile 2>&1
   mv "$tmpDir/$fileName" "$defaultLibraryDir/$fileName"
   timeToLog

--- a/scripts/download-and-cut.sh
+++ b/scripts/download-and-cut.sh
@@ -15,7 +15,7 @@ set -e
 #Directory where downloaded mp3 files are stored - kamerdyner's library
 defaultLibraryDir='/media/pen/kamerdyner'
 #Temp dir where downloading and encoding happens
-tmpDir='/media/pen/kamerdyner/tmp'
+tmpDir='/tmp/kamerdyner'
 #Log file:
 logFile="$tmpDir/YTlog.txt"
 

--- a/scripts/download-and-cut.sh
+++ b/scripts/download-and-cut.sh
@@ -71,14 +71,7 @@ function downloadYoutube {
 
 function cutMP3 {
   nameToLog "cutMP3"
-	if [ -f "$tmpDir/ffmpeg.mp3" ]; then
-		rm "$tmpDir/ffmpeg.mp3"
- 	fi
- 	mv "$tmpDir/$1" "$tmpDir/ffmpeg.mp3"
- 	ffmpeg -y -i "$tmpDir/ffmpeg.mp3" -ss $2 -to $3 -c copy "$defaultLibraryDir/$1" >> $logFile 2>&1
- 	if [ -f "$tmpDir/ffmpeg.mp3" ]; then
- 		rm "$tmpDir/ffmpeg.mp3"
- 	fi
+ 	ffmpeg -y -i "$tmpDir/$1" -ss $2 -to $3 "$tmpDir/$1" >> $logFile 2>&1
 }
 
 function sepToLog {
@@ -112,9 +105,8 @@ else
   fileName=`downloadYoutube "$1" "$2"`
   if [ "$#" -eq 4 ]; then
     cutMP3 "$fileName" "$3" "$4"
-  else
-    echo mv "$tmpDir/$fileName" "$defaultLibraryDir/$fileName" >> $logFile 2>&1
-    mv "$tmpDir/$fileName" "$defaultLibraryDir/$fileName"
   fi
+  echo mv "$tmpDir/$fileName" "$defaultLibraryDir/$fileName" >> $logFile 2>&1
+  mv "$tmpDir/$fileName" "$defaultLibraryDir/$fileName"
   timeToLog
 fi

--- a/scripts/download-and-cut.sh
+++ b/scripts/download-and-cut.sh
@@ -50,7 +50,7 @@ function downloadYoutube {
   # usage: downloadYoutube "url" "tag"
   outputTemplate="%(id)s.%(ext)s"
   #checkIfPackageInstalled "youtube-dl" ## &>> $logFile
-  parameters="--extract-audio --audio-format mp3"
+  parameters="--format bestaudio/best --extract-audio --audio-format mp3"
 
   outputFileName=`youtube-dl --get-filename $parameters -o "$outputTemplate" "$1"`
   outputName=`echo "$outputFileName" | cut -d'.' -f1`

--- a/scripts/download-and-cut.sh
+++ b/scripts/download-and-cut.sh
@@ -2,7 +2,8 @@
 # Script used to download audio from Youtube video and extract specified part of it
 # Depends on all possible codecs that Youtube video files depend on including
 # Prerequisites:
-# sudo apt-get install libav-tools libavcodec-extra youtube-dl ffmpeg
+# sudo apt-get install libav-tools libavcodec-extra ffmpeg
+# sudo pip install youtube-dl ffmpeg-normalize
 
 # Sample usage:
 # ./download-and-cut.sh "https://www.youtube.com/watch?v=QuwvJw1mrWY" "BedzieDzialacNIE" "00:00:01" "00:00:04"


### PR DESCRIPTION
This change introduces improvements to download-and-cut.sh utility used by Franz.

* Files aren't downloaded to flash drive before post-processing, standard linux volatile `/tmp` (tmpfs ramdisk) is used instead. This improves overall performance as all I/O operations are much faster.
* Youtube-dl now attempts audio-only download before anything else. This improves performance as it shortens the download time by not downloading unnecessary video data.
* Attempt two-pass EBU R128 audio normalization provided by ffmpeg-normalize utility if available. This should solve the problem of sounds playing with different amplitude levels, as all already existing sound files are subject to be normalized the same way on live environment.